### PR TITLE
#3 model introduced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+tmp.ts

--- a/public/document.json
+++ b/public/document.json
@@ -1,0 +1,162 @@
+[
+  {
+    "id": "1",
+    "title": "これはid=1",
+    "url": "link",
+    "markdownContent": {
+      "lead": [
+        "# Hello World",
+        "## hoge",
+        "- a",
+        "- *b*",
+        "  - **c**"
+      ],
+      "procedure": [
+        "Just a link: https://reactjs.com.",
+        "",
+        "~~取り消し線~~",
+        "* [ ] hoge",
+        "* [x] piyo"
+      ],
+      "question": [
+        "`aiueo`",
+        "",
+        "aiueo"
+      ]
+    },
+    "options": [
+      {
+        "label": "これは2に行く",
+        "next": "2"
+      },
+      {
+        "label": "これは4に行く",
+        "next": "4"
+      },
+      {
+        "label": "これは3に行く",
+        "next": "3"
+      }
+    ]
+  },
+  {
+    "id": "2",
+    "title": "これはid=2",
+    "url": "link",
+    "markdownContent": {
+      "lead": [
+        "# Hello World",
+        "## fuga",
+        "- a",
+        "- *b*",
+        "\t- **c**"
+      ],
+      "procedure": [
+        "Just a link: https://reactjs.com.",
+        "",
+        "~~取り消し線~~",
+        "* [ ] hoge",
+        "* [x] piyo"
+      ],
+      "question": [
+        "`aiueo`",
+        "",
+        "aiueo"
+      ]
+    },
+    "options": [
+      {
+        "label": "これは1に行く",
+        "next": "1"
+      },
+      {
+        "label": "これは4に行く",
+        "next": "4"
+      },
+      {
+        "label": "これは3に行く",
+        "next": "3"
+      }
+    ]
+  },
+  {
+    "id": "3",
+    "title": "これはid=3",
+    "url": "link",
+    "markdownContent": {
+      "lead": [
+        "# Hello World",
+        "## foo",
+        "- a",
+        "- *b*",
+        "\t- **c**"
+      ],
+      "procedure": [
+        "Just a link: https://reactjs.com.",
+        "",
+        "~~取り消し線~~",
+        "* [ ] hoge",
+        "* [x] piyo"
+      ],
+      "question": [
+        "`aiueo`",
+        "",
+        "aiueo"
+      ]
+    },
+    "options": [
+      {
+        "label": "これは2に行く",
+        "next": "2"
+      },
+      {
+        "label": "これは4に行く",
+        "next": "4"
+      },
+      {
+        "label": "これは1に行く",
+        "next": "1"
+      }
+    ]
+  },
+  {
+    "id": "4",
+    "title": "これはid=4",
+    "url": "link",
+    "markdownContent": {
+      "lead": [
+        "# Hello World",
+        "## bar",
+        "- a",
+        "- *b*",
+        "\t- **c**"
+      ],
+      "procedure": [
+        "Just a link: https://reactjs.com.",
+        "",
+        "~~取り消し線~~",
+        "* [ ] hoge",
+        "* [x] piyo"
+      ],
+      "question": [
+        "`aiueo`",
+        "",
+        "aiueo"
+      ]
+    },
+    "options": [
+      {
+        "label": "これは2に行く",
+        "next": "2"
+      },
+      {
+        "label": "これは1に行く",
+        "next": "1"
+      },
+      {
+        "label": "これは3に行く",
+        "next": "3"
+      }
+    ]
+  }
+]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,74 +1,77 @@
-import { Box, Container, Grid, Paper } from "@mui/material";
-import { VFC } from "react";
+import { Box, Container, Grid, Paper, Button } from "@mui/material";
+import { useEffect, useState, VFC } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import getDocument from "./api/api";
 
 const App: VFC = () => {
   type documentObject = {
+    title: string;
     id: string;
     url: string;
     markdownContent: {
-      lead?: string;
-      procedure?: string;
-      question: string;
+      lead?: string[];
+      procedure?: string[];
+      question: string[];
     };
     options: { label: string; next: string }[];
   };
 
-  const leadMarkdown: string = `# Hello World
-  ## hoge
-  - a
-  - *b*
-    - **c**
-  `;
+  const [content, setContent] = useState<documentObject | null>(null);
 
-  /*
-    remark-gfmを使うと
-    ・取り消し線
-    ・テーブル
-    ・URL
-    ・タスクリスト
-    が使える
-  */
-  const procedureMarkdown: string = `Just a link: https://reactjs.com.
-
-  ~~取り消し線~~
-  * [ ] hoge
-  * [x] piyo
-  `;
-
-  const questionMarkdown: string = `\`aiueo\`
-
-  aiueo`;
-
-  const documentObject: documentObject = {
-    id: "1",
-    url: "2",
-    markdownContent: {
-      lead: leadMarkdown,
-      procedure: procedureMarkdown,
-      question: questionMarkdown,
-    },
-    options: [
-      {
-        label: "a",
-        next: "2",
-      },
-    ],
+  const handleDocumentChange = (next: string) => {
+    getDocument(next).then((document) => {
+      setContent(document);
+    });
   };
+
+  useEffect(() => {
+    getDocument("1").then((data: documentObject) => {
+      setContent(data);
+    });
+  }, []);
+
+  if (content === null) {
+    return <h1>Loading...</h1>;
+  }
 
   return (
     <Box sx={{ backgroundColor: "#f5f5f5", py: 3 }}>
       <Container>
         <Grid container rowSpacing={2}>
-          {Object.entries(documentObject.markdownContent).map(
+          {Object.entries(content.markdownContent).map(
             ([key, data]): JSX.Element => {
               return (
                 <Grid item xs={12} key={key}>
                   <Paper elevation={5} sx={{ p: 2 }}>
                     <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                      {data}
+                      {data.join("\n")}
                     </ReactMarkdown>
+                    {key === "question" && (
+                      <Grid container columnSpacing={2}>
+                        {content.options.map(({ label, next }, key) => {
+                          return (
+                            <Grid
+                              item
+                              xs={4}
+                              key={key}
+                              sx={{
+                                display: "flex",
+                                justifyContent: "center",
+                                alignItems: "center",
+                              }}
+                            >
+                              <Button
+                                variant="contained"
+                                onClick={() => handleDocumentChange(next)}
+                              >
+                                {label}
+                              </Button>
+                            </Grid>
+                          );
+                        })}
+                      </Grid>
+                    )}
                   </Paper>
                 </Grid>
               );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,12 @@
-import { Box, Container, Grid, Paper, Button } from "@mui/material";
+import {
+  Box,
+  AppBar,
+  Typography,
+  Container,
+  Grid,
+  Paper,
+  Button,
+} from "@mui/material";
 import { useEffect, useState, VFC } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -36,8 +44,13 @@ const App: VFC = () => {
   }
 
   return (
-    <Box sx={{ backgroundColor: "#f5f5f5", py: 3 }}>
-      <Container>
+    <Box sx={{ backgroundColor: "#f5f5f5" }}>
+      <AppBar position="static">
+        <Typography variant="h3" component="div" sx={{ p: 2, pl: 2 }}>
+          {content.title}
+        </Typography>
+      </AppBar>
+      <Container sx={{ py: 3 }}>
         <Grid container rowSpacing={2}>
           {Object.entries(content.markdownContent).map(
             ([key, data]): JSX.Element => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,20 +11,9 @@ import { useEffect, useState, VFC } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import getDocument from "./api/api";
+import { documentObject } from "./type";
 
 const App: VFC = () => {
-  type documentObject = {
-    title: string;
-    id: string;
-    url: string;
-    markdownContent: {
-      lead?: string[];
-      procedure?: string[];
-      question: string[];
-    };
-    options: { label: string; next: string }[];
-  };
-
   const [content, setContent] = useState<documentObject | null>(null);
 
   const handleDocumentChange = (next: string) => {

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,0 +1,11 @@
+const getDocument = async(queryId: string) => {
+    const response = await fetch(
+      `/document.json`
+    );
+    const data = await response.json();
+    for (const document of data) {
+        if (document.id === queryId) return document;
+    }
+}
+
+export default getDocument;

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,0 +1,11 @@
+export type documentObject = {
+  title: string;
+  id: string;
+  url: string;
+  markdownContent: {
+    lead?: string[];
+    procedure?: string[];
+    question: string[];
+  };
+  options: { label: string; next: string }[];
+};


### PR DESCRIPTION
#3 modelの作成とドキュメントの遷移を実装しました．

## 変更内容
- 外部ファイル(public/document.json)からapi(src/api/api.ts)を通じてデータを取得するように変更
　- それに従い，データ未取得時にはLoadingが表示されるようにした
- 遷移ボタンの追加
- headerを追加し，今表示されているdocumentのtitleを表示
- documentObjectの型宣言を(src/type.ts)に切り分け